### PR TITLE
LZ.PHP.Function <?php fix

### DIFF
--- a/components/LZ.PHP.Functions.php
+++ b/components/LZ.PHP.Functions.php
@@ -250,7 +250,7 @@
 	</div>
 </body>
 </html>
-	<?
+	<?php
 			exit;
 		}
 


### PR DESCRIPTION
LZ.PHP.Function의 <?로된 부분 때문에 최신버전의 PHP에서 작동하지 않는 문제를 수정했습니다.
